### PR TITLE
Add battle scene and random encounters. Fixes #32 #33 #34

### DIFF
--- a/scenes/Battle.tscn
+++ b/scenes/Battle.tscn
@@ -1,0 +1,51 @@
+[gd_scene format=3 uid="uid://bkx5g07vuuhvg"]
+
+[ext_resource type="Script" uid="uid://by5ni4p8lebxy" path="res://scenes/battle.gd" id="1_bdmed"]
+
+[node name="Battle" type="Control" unique_id=1667605991]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_bdmed")
+
+[node name="PlayerHP" type="Label" parent="." unique_id=255616599]
+layout_mode = 0
+offset_left = 1.0
+offset_top = 129.0
+offset_right = 41.0
+offset_bottom = 152.0
+
+[node name="EnemyHP" type="Label" parent="." unique_id=592293777]
+layout_mode = 0
+offset_left = 176.0
+offset_top = 7.0
+offset_right = 216.0
+offset_bottom = 30.0
+
+[node name="DialogueLabel" type="Label" parent="." unique_id=853731098]
+layout_mode = 0
+offset_left = 69.0
+offset_top = 71.0
+offset_right = 109.0
+offset_bottom = 94.0
+
+[node name="ActionButtons" type="VBoxContainer" parent="." unique_id=1073188630]
+layout_mode = 0
+offset_left = 145.0
+offset_top = 110.0
+offset_right = 244.0
+offset_bottom = 176.0
+
+[node name="AttackButton" type="Button" parent="ActionButtons" unique_id=1693663693]
+layout_mode = 2
+text = "ATTACK"
+
+[node name="RunButton" type="Button" parent="ActionButtons" unique_id=1852598323]
+layout_mode = 2
+text = "RUN"
+
+[connection signal="pressed" from="ActionButtons/AttackButton" to="." method="_on_attack_button_pressed"]
+[connection signal="pressed" from="ActionButtons/RunButton" to="." method="_on_run_button_pressed"]

--- a/scenes/battle.gd
+++ b/scenes/battle.gd
@@ -1,0 +1,120 @@
+extends Control
+
+signal battle_finished
+
+# 1. Define our State Machine
+enum State { INIT, PLAYER_TURN, ENEMY_TURN, WIN, LOSE, END }
+var current_state = State.INIT
+
+# 2. Simple Stats (Keep it simple for the assignment)
+var player_max_hp = 20
+var player_hp = 20
+var enemy_max_hp = 15
+var enemy_hp = 15
+
+# 3. Node References (Drag and drop your nodes here holding CTRL)
+@onready var dialogue_label = $DialogueLabel
+@onready var action_buttons = $ActionButtons
+@onready var player_hp_label = $PlayerHP
+@onready var enemy_hp_label = $EnemyHP
+
+func _ready():
+	# Start the battle as soon as the scene loads
+	start_battle()
+
+func start_battle():
+	current_state = State.INIT
+	update_ui()
+	action_buttons.hide() # Hide buttons until it's our turn
+	
+	display_text("A wild monster appeared!")
+	# Wait 1.5 seconds so the player can read the text
+	await get_tree().create_timer(1.5).timeout 
+	
+	player_turn()
+
+func player_turn():
+	current_state = State.PLAYER_TURN
+	display_text("What will you do?")
+	action_buttons.show() # Show Attack/Run buttons
+
+# Make sure to connect your Attack button's "pressed" signal to this function!
+func _on_attack_button_pressed():
+	if current_state != State.PLAYER_TURN: 
+		return # Prevent clicking if it's not our turn
+		
+	action_buttons.hide()
+	display_text("You attacked!")
+	await get_tree().create_timer(1.0).timeout
+	
+	# Deal damage
+	enemy_hp -= 5
+	enemy_hp = max(0, enemy_hp) # Prevents HP from going into negatives
+	update_ui()
+	
+	# Check for win condition
+	if enemy_hp == 0:
+		win()
+	else:
+		enemy_turn()
+
+# Make sure to connect your Run button's "pressed" signal to this function!
+func _on_run_button_pressed():
+	if current_state != State.PLAYER_TURN: 
+		return
+		
+	action_buttons.hide()
+	display_text("You tried to run away...")
+	await get_tree().create_timer(1.0).timeout
+	
+	# 50% chance to run away successfully
+	if randf() > 0.5: 
+		display_text("Got away safely!")
+		await get_tree().create_timer(1.5).timeout
+		end_battle()
+	else:
+		display_text("Failed to escape!")
+		await get_tree().create_timer(1.5).timeout
+		enemy_turn()
+
+func enemy_turn():
+	current_state = State.ENEMY_TURN
+	display_text("The enemy attacks!")
+	await get_tree().create_timer(1.0).timeout
+	
+	# Enemy deals damage
+	player_hp -= 4
+	player_hp = max(0, player_hp)
+	update_ui()
+	
+	# Check for lose condition
+	if player_hp == 0:
+		lose()
+	else:
+		player_turn()
+
+func win():
+	current_state = State.WIN
+	display_text("You won!")
+	await get_tree().create_timer(1.5).timeout
+	end_battle()
+
+func lose():
+	current_state = State.LOSE
+	display_text("You blacked out!")
+	await get_tree().create_timer(1.5).timeout
+	end_battle()
+
+func end_battle():
+	current_state = State.END
+	battle_finished.emit()
+	# Close the battle scene and return to the overworld map
+	queue_free() 
+
+# Helper functions to keep code clean
+func display_text(text: String):
+	dialogue_label.text = text
+
+func update_ui():
+	player_hp_label.text = "Player HP: " + str(player_hp) + "/" + str(player_max_hp)
+	enemy_hp_label.text = "Enemy HP: " + str(enemy_hp) + "/" + str(enemy_max_hp)

--- a/scenes/battle.gd
+++ b/scenes/battle.gd
@@ -2,17 +2,17 @@ extends Control
 
 signal battle_finished
 
-# 1. Define our State Machine
+# State Machine
 enum State { INIT, PLAYER_TURN, ENEMY_TURN, WIN, LOSE, END }
 var current_state = State.INIT
 
-# 2. Simple Stats (Keep it simple for the assignment)
+# Simple Stats
 var player_max_hp = 20
 var player_hp = 20
 var enemy_max_hp = 15
 var enemy_hp = 15
 
-# 3. Node References (Drag and drop your nodes here holding CTRL)
+# Node References (Drag and drop your nodes here holding CTRL)
 @onready var dialogue_label = $DialogueLabel
 @onready var action_buttons = $ActionButtons
 @onready var player_hp_label = $PlayerHP
@@ -38,7 +38,6 @@ func player_turn():
 	display_text("What will you do?")
 	action_buttons.show() # Show Attack/Run buttons
 
-# Make sure to connect your Attack button's "pressed" signal to this function!
 func _on_attack_button_pressed():
 	if current_state != State.PLAYER_TURN: 
 		return # Prevent clicking if it's not our turn
@@ -58,7 +57,6 @@ func _on_attack_button_pressed():
 	else:
 		enemy_turn()
 
-# Make sure to connect your Run button's "pressed" signal to this function!
 func _on_run_button_pressed():
 	if current_state != State.PLAYER_TURN: 
 		return

--- a/scenes/battle.gd.uid
+++ b/scenes/battle.gd.uid
@@ -1,0 +1,1 @@
+uid://by5ni4p8lebxy

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -56,7 +56,23 @@ func move(delta):
 		position = initial_position + (TILE_SIZE * input_direction)
 		percent_moved_to_next_tile = 0.0
 		is_moving = false
+		try_start_battle()
 	# Else we're still on the way to the next tile, so interpolate (smoothly move) between start and end position
 	else:
 		position = initial_position + (TILE_SIZE * input_direction * percent_moved_to_next_tile)
 	
+
+const BATTLE_SCENE := preload("res://scenes/Battle.tscn")
+
+func try_start_battle():
+	if randf() < 0.10: # 10% encounter chance
+		var battle = BATTLE_SCENE.instantiate()
+		get_tree().current_scene.add_child(battle) # overlay on overworld
+		set_physics_process(false) # optional: freeze player during battle
+		battle.battle_finished.connect(_on_battle_finished)
+
+func _on_battle_finished():
+	set_physics_process(true)
+	input_direction = Vector2.ZERO
+	is_moving = false
+	percent_moved_to_next_tile = 0.0

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -17,6 +17,7 @@ var percent_moved_to_next_tile = 0.0
 
 # Function runs automatically when game starts
 func _ready():
+	randomize()
 	initial_position = position # Gets the position of the player
 
 # Runs every frame and handles the overall movement, e.g. checks if we're moving or not, gets input if we're stationary, and updates position if we're moving


### PR DESCRIPTION
Add simple turn-based battle system

- Create Battle scene (Battle.tscn, battle.gd) with a state machine 
  managing player turns, enemy turns, and win/lose/end states.
- Implement basic HP tracking, Attack/Run UI, and battle dialog.
- Emit 'battle_finished' signal when combat concludes.
- Update player.gd to include a 10% random encounter chance via 
  a new 'try_start_battle' function.
- Pause player physics during combat and resume upon receiving 
  the 'battle_finished' signal.