### PR TITLE
Fixes #46 adjusted tall grass script

### DIFF
--- a/scripts/tall_grass.gd
+++ b/scripts/tall_grass.gd
@@ -15,7 +15,8 @@ func _ready() -> void:
 # On when we enter tall grass, we play the "Stepped" tall grass animation
 func _on_area_2d_body_entered(body: Node2D) -> void:
 	anim_player.play("Stepped")
-	#check if the object stepping into the grass is player
+	# Check if the object stepping into the grass is player
 	if body.has_method("try_start_battle"):
+		# Wait a tiny bit for the player to finish moving onto the tile before triggering battle
+		await get_tree().create_timer(0.16).timeout
 		body.try_start_battle()
-	pass # Replace with function body.


### PR DESCRIPTION
Adjusted tall grass script so that battle doesn't start until after 0.16 seconds so that we're inside the tall grass tile when battle starts!